### PR TITLE
Fix Badge Interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /.idea
+/vendor

--- a/src/Page.php
+++ b/src/Page.php
@@ -5,6 +5,7 @@ namespace KodiComponents\Navigation;
 use Illuminate\Routing\UrlGenerator;
 use KodiComponents\Support\HtmlAttributes;
 use KodiComponents\Navigation\Contracts\PageInterface;
+use KodiComponents\Navigation\Contracts\BadgeInterface;
 
 class Page extends Navigation implements PageInterface
 {


### PR DESCRIPTION
Without this `use KodiComponents\Navigation\Contracts\BadgeInterface` badges dont work. Issue heads on https://github.com/LaravelRUS/SleepingOwlAdmin
I can fix this in sleepingowladmin by overwrite in derived Page class, but seems issus is here.
