### PR TITLE
Fix for findActive with very long urls

### DIFF
--- a/src/Navigation.php
+++ b/src/Navigation.php
@@ -314,7 +314,7 @@ class Navigation implements NavigationInterface
             
             if (strpos($url, $page->getUrl()) !== false) {
                 $foundPages[] = [
-                    levenshtein($url, $page->getUrl()),
+                    levenshtein(substr($url, 0, 255), substr($page->getUrl(), 0, 255)),
                     $page,
                 ];
             }


### PR DESCRIPTION
Prevents findActive failing if $url or $page->getUrl() is over 255 characters long.

levenshtein cannot handle strings over 255 characters long, which they can be, if submitting a complex search form, for example.